### PR TITLE
OutOfBounds Exception when using the Service command

### DIFF
--- a/node/src/main/java/dev/httpmarco/polocloud/node/commands/CommandParser.java
+++ b/node/src/main/java/dev/httpmarco/polocloud/node/commands/CommandParser.java
@@ -57,8 +57,9 @@ public class CommandParser {
                 for (int i = 0; i < syntaxCommand.arguments().length; i++) {
                     var argument = syntaxCommand.arguments()[i];
 
-                    if (i >= args.length)
+                    if (i >= args.length) {
                         return false;
+                    }
 
                     var rawInput = args[i];
 

--- a/node/src/main/java/dev/httpmarco/polocloud/node/commands/CommandParser.java
+++ b/node/src/main/java/dev/httpmarco/polocloud/node/commands/CommandParser.java
@@ -56,6 +56,10 @@ public class CommandParser {
 
                 for (int i = 0; i < syntaxCommand.arguments().length; i++) {
                     var argument = syntaxCommand.arguments()[i];
+
+                    if (i >= args.length)
+                        return false;
+
                     var rawInput = args[i];
 
                     if(argument instanceof StringArrayArgument arrayArgument) {

--- a/node/src/main/java/dev/httpmarco/polocloud/node/commands/CommandParser.java
+++ b/node/src/main/java/dev/httpmarco/polocloud/node/commands/CommandParser.java
@@ -58,7 +58,8 @@ public class CommandParser {
                     var argument = syntaxCommand.arguments()[i];
 
                     if (i >= args.length) {
-                        return false;
+                        provedSyntax = false;
+                        break;
                     }
 
                     var rawInput = args[i];


### PR DESCRIPTION
If you execute the "service" or "ser" command and put a non defined argument in it, it generates a OutOfBounds Exception as shown in the picture below.

![Screenshot_20240831_142249](https://github.com/user-attachments/assets/a19187c0-6434-4665-8760-d6551081dce5)

In my fix I again check the args length inside the most inner for-loop.

Picture with the fix:
![image](https://github.com/user-attachments/assets/e2552eef-a512-4b81-acb2-10c481465dea)
