### PR TITLE
Platform dependency caching tasks

### DIFF
--- a/common/src/main/kotlin/dev/httpmarco/polocloud/common/filesystem/CopyDirectoryContent.kt
+++ b/common/src/main/kotlin/dev/httpmarco/polocloud/common/filesystem/CopyDirectoryContent.kt
@@ -1,0 +1,21 @@
+package dev.httpmarco.polocloud.common.filesystem
+
+import java.nio.file.CopyOption
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+import kotlin.io.path.listDirectoryEntries
+
+fun copyDirectoryContent(source: Path, destination: Path, vararg options: CopyOption) {
+    if (!source.isDirectory()) return
+
+    source.listDirectoryEntries().forEach { file ->
+        val destinationFile = destination.resolve(file.fileName)
+        if (file.isDirectory()) {
+            destinationFile.toFile().mkdirs()
+            copyDirectoryContent(file, destinationFile)
+        } else {
+            Files.copy(file, destinationFile, *options)
+        }
+    }
+}

--- a/metadata/platforms/folia.json
+++ b/metadata/platforms/folia.json
@@ -12,6 +12,9 @@
     "SPIGOT_SERVER_PROPERTIES",
     "PAPER_PROXY_SUPPORT_TASK"
   ],
+  "preTasks": [
+    "LOAD_PAPER_DEPENDENCIES_TASK"
+  ],
   "versions": [
     {
       "version": "1.21.6",

--- a/metadata/platforms/leaf.json
+++ b/metadata/platforms/leaf.json
@@ -12,6 +12,9 @@
     "SPIGOT_SERVER_PROPERTIES",
     "PAPER_PROXY_SUPPORT_TASK"
   ],
+  "preTasks": [
+    "LOAD_PAPER_DEPENDENCIES_TASK"
+  ],
   "versions": [
     {
       "version": "1.21.8",

--- a/metadata/platforms/paper.json
+++ b/metadata/platforms/paper.json
@@ -33,6 +33,9 @@
     "SPIGOT_SERVER_PROPERTIES",
     "PAPER_PROXY_SUPPORT_TASK"
   ],
+  "preTasks": [
+    "LOAD_PAPER_DEPENDENCIES_TASK"
+  ],
   "versions": [
     {
       "version": "1.21.8",

--- a/metadata/platforms/pumpkin.json
+++ b/metadata/platforms/pumpkin.json
@@ -16,5 +16,6 @@
       "version": "1.21.7",
       "commitHash": "c01e0b93b94e5239308ad08faf6ae0db72d5b9bb"
     }
-  ]
+  ],
+  "setFileName": false
 }

--- a/metadata/platforms/purpur.json
+++ b/metadata/platforms/purpur.json
@@ -11,6 +11,9 @@
     "SPIGOT_SERVER_PROPERTIES",
     "PAPER_PROXY_SUPPORT_TASK"
   ],
+  "preTasks": [
+    "LOAD_PAPER_DEPENDENCIES_TASK"
+  ],
   "flags": [
     "-XX:+UseG1GC",
     "-XX:+ParallelRefProcEnabled",

--- a/metadata/tasks/paperLoadDependencies.json
+++ b/metadata/tasks/paperLoadDependencies.json
@@ -1,0 +1,14 @@
+{
+  "name": "LOAD_PAPER_DEPENDENCIES_TASK",
+  "steps": [
+    {
+      "name": "Load dependencies",
+      "description": "Loading paper dependencies to cache them",
+      "filename": "",
+      "action": {
+        "type": "PlatformExecuteCommandAction",
+        "command": "java -Dpaperclip.patchonly=true -jar %filename%"
+      }
+    }
+  ]
+}

--- a/platforms/src/main/kotlin/dev/httpmarco/polocloud/platforms/Platform.kt
+++ b/platforms/src/main/kotlin/dev/httpmarco/polocloud/platforms/Platform.kt
@@ -1,5 +1,6 @@
 package dev.httpmarco.polocloud.platforms
 
+import dev.httpmarco.polocloud.common.filesystem.copyDirectoryContent
 import dev.httpmarco.polocloud.common.os.currentCPUArchitecture
 import dev.httpmarco.polocloud.common.os.currentOS
 import dev.httpmarco.polocloud.platforms.bridge.Bridge
@@ -86,7 +87,7 @@ class Platform(
         tasks().forEach { it.runTask(servicePath, environment) }
 
         // copy the platform file to the service path
-        Files.copy(path, servicePath.resolve(path.name), StandardCopyOption.REPLACE_EXISTING)
+        copyDirectoryContent(path.parent, servicePath, StandardCopyOption.REPLACE_EXISTING)
 
         if (bridge == null) {
             return

--- a/platforms/src/main/kotlin/dev/httpmarco/polocloud/platforms/Platform.kt
+++ b/platforms/src/main/kotlin/dev/httpmarco/polocloud/platforms/Platform.kt
@@ -45,7 +45,9 @@ class Platform(
     // the tasks that should be run after the platform download
     private val preTasks: List<String> = emptyList(),
     // if true, the polocloud server icon will be copied to the service path
-    private val copyServerIcon: Boolean = true
+    private val copyServerIcon: Boolean = true,
+    // if false, the downloaded file will be named "download" to be changed by preTask
+    private val setFileName: Boolean = true
 ) {
 
     fun prepare(servicePath: Path, version: String, environment: PlatformParameters) {
@@ -54,6 +56,8 @@ class Platform(
         // Implementation details would depend on the specific requirements of the platform.
         val path = Path("local/metadata/cache/$name/$version/$name-$version" + language.suffix())
         val version = this.version(version)
+
+        environment.addParameter("filename", path.fileName)
 
         if (version == null) {
             throw PlatformVersionInvalidException()
@@ -71,7 +75,7 @@ class Platform(
                 replacedUrl = replacedUrl.replace("%$key%", value.jsonPrimitive.content)
             }
 
-            val downloadFile = if (preTasks.isEmpty()) path.toFile() else path.parent.resolve("download").toFile()
+            val downloadFile = if (setFileName) path.toFile() else path.parent.resolve("download").toFile()
 
             URI(
                 replacedUrl

--- a/platforms/src/main/kotlin/dev/httpmarco/polocloud/platforms/tasks/actions/PlatformExecuteCommandAction.kt
+++ b/platforms/src/main/kotlin/dev/httpmarco/polocloud/platforms/tasks/actions/PlatformExecuteCommandAction.kt
@@ -15,7 +15,7 @@ class PlatformExecuteCommandAction(val command: String) : PlatformAction() {
         environment: PlatformParameters
     ) {
         val builder = ProcessBuilder()
-        builder.command("sh", "-c", command)
+        builder.command("sh", "-c", environment.modifyValueWithEnvironment(command))
         builder.directory(file.toFile())
         val process = builder.start()
 


### PR DESCRIPTION
Features implemented:

- Copy everything in the cache folder to the service folder
- preTask to cache dependencies for paper forks (paper, leaf, purpur, folia)
- setFileName flag for Platform (specifies if the downloaded file should be named like the executable or not, is needed for pumpkin)

fixes #338 