### PR TITLE
fix: use executable in service folder instead of cache folder for rust/go

### DIFF
--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/LocalRuntimeFactory.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/LocalRuntimeFactory.kt
@@ -4,6 +4,7 @@ import dev.httpmarco.polocloud.agent.Agent
 import dev.httpmarco.polocloud.agent.i18n
 import dev.httpmarco.polocloud.agent.runtime.RuntimeFactory
 import dev.httpmarco.polocloud.agent.services.AbstractService
+import dev.httpmarco.polocloud.common.os.currentOS
 import dev.httpmarco.polocloud.common.version.polocloudVersion
 import dev.httpmarco.polocloud.platforms.PlatformParameters
 import dev.httpmarco.polocloud.platforms.Platform
@@ -170,7 +171,7 @@ class LocalRuntimeFactory(var localRuntime: LocalRuntime) : RuntimeFactory<Local
             }
 
             PlatformLanguage.GO, PlatformLanguage.RUST -> {
-                commands.add("${abstractService.group.applicationPlatformFile().absolute()}")
+                commands.addAll(currentOS.executableCurrentDirectoryCommand(abstractService.group.applicationPlatformFile().name))
             }
         }
         return commands

--- a/common/src/main/kotlin/dev/httpmarco/polocloud/common/os/OS.kt
+++ b/common/src/main/kotlin/dev/httpmarco/polocloud/common/os/OS.kt
@@ -1,9 +1,18 @@
 package dev.httpmarco.polocloud.common.os
 
 //downloadName will be replace by FlorianLang06 later
-enum class OS(val nativeExecutableSuffix: String?, val downloadName: String) {
-    WIN("exe", "windows"),
-    LINUX(null, "linux"),
-    MACOS(null, "darwin"),
-    UNKNOWN(null, "")
+enum class OS(
+    val nativeExecutableSuffix: String?,
+    val downloadName: String,
+    val shellPrefix: Array<String>,
+    val currentDirectoryPrefix: String?
+) {
+    WIN("exe", "windows", arrayOf("cmd", "/c"), null),
+    LINUX(null, "linux", arrayOf("sh", "-c"), "./"),
+    MACOS(null, "darwin", arrayOf("sh", "-c"), "./"),
+    UNKNOWN(null, "", emptyArray(), null);
+
+    fun executableCurrentDirectoryCommand(filename: String): Array<String> {
+        return arrayOf(*shellPrefix, "${currentDirectoryPrefix ?: ""}$filename")
+    }
 }

--- a/platforms/src/main/kotlin/dev/httpmarco/polocloud/platforms/tasks/actions/PlatformExecuteCommandAction.kt
+++ b/platforms/src/main/kotlin/dev/httpmarco/polocloud/platforms/tasks/actions/PlatformExecuteCommandAction.kt
@@ -1,6 +1,5 @@
 package dev.httpmarco.polocloud.platforms.tasks.actions
 
-import dev.httpmarco.polocloud.common.os.OS
 import dev.httpmarco.polocloud.common.os.currentOS
 import dev.httpmarco.polocloud.platforms.PlatformParameters
 import dev.httpmarco.polocloud.platforms.tasks.PlatformTaskStep
@@ -14,9 +13,8 @@ class PlatformExecuteCommandAction(val command: String) : PlatformAction() {
     ) {
         val builder = ProcessBuilder()
 
-        val prefix = if (currentOS == OS.WIN) arrayOf("cmd", "/c") else arrayOf("sh", "-c")
 
-        builder.command(*prefix, environment.modifyValueWithEnvironment(command))
+        builder.command(*currentOS.shellPrefix, environment.modifyValueWithEnvironment(command))
         builder.directory(file.toFile())
         val process = builder.start()
 


### PR DESCRIPTION
# Pull Request

## Description
This fix changes that for rust and go services the file in the service-folder is used instead of the cache folder.

## Changes
- added `shellPrefix` variable to `OS` to get the prefix need to execute something with the native shell (this is needed because if you don't add this programs in the PATH variable will not be found)
- added `currentDirectoryPrefix` variable to `OS` (This is needed because linux/unix will need `./` before a executable in the current folder)
- added `executableCurrentDirectoryCommand` function to `OS` to the whole command to execute a native executable in the current folder
- used the new function in the execution of the service and used shellPrefix in the CommandAction

## Motivation and Context
fixes #477 

## How Has This Been Tested?
I tested if pumpkin starts on Linux (Test for Windows should be done) and if paperCacheTask works because the `shellPrefix` is used in there.
