### PR TITLE
Fixed tab complete in service screen (fixes #506)

### DIFF
--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/terminal/JLine3Completer.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/terminal/JLine3Completer.kt
@@ -1,7 +1,6 @@
 package dev.httpmarco.polocloud.agent.runtime.local.terminal
 
 import dev.httpmarco.polocloud.agent.runtime.local.terminal.arguments.InputContext
-import dev.httpmarco.polocloud.agent.runtime.local.terminal.commands.CommandService
 import dev.httpmarco.polocloud.agent.runtime.local.terminal.commands.CommandSyntax
 import org.jline.reader.Candidate
 import org.jline.reader.Completer
@@ -25,6 +24,25 @@ class JLine3Completer(private val terminal: JLine3Terminal) : Completer {
             return
         }
 
+        if(terminal.screenService.isRecording()) {
+            if(line.wordIndex() != 0) {
+                // we have no arguments for service commands
+                return
+            }
+            val service = terminal.screenService.displayedAbstractService()
+            if(service == null) {
+                // service is not set
+                return
+            }
+
+            val commands = arrayOf("exit", service.group.platform().shutdownCommand)
+            for (command in commands) {
+                if (command.startsWith(line.word())) {
+                    candidates.add(Candidate(command))
+                }
+            }
+            return
+        }
 
         if (line.wordIndex() == 0) {
             // we only display the command names -> not aliases

--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/terminal/JLine3Reading.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/terminal/JLine3Reading.kt
@@ -34,7 +34,7 @@ class JLine3Reading(
                     continue
                 }
 
-                if (screenService.isRecoding()) {
+                if (screenService.isRecording()) {
                     if (line == "exit") {
                         screenService.stopCurrentRecording()
                         continue

--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/terminal/screen/ServiceScreenController.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/terminal/screen/ServiceScreenController.kt
@@ -26,7 +26,7 @@ class ServiceScreenController(val terminal: JLine3Terminal) {
 
     fun stopCurrentRecording() {
 
-        if (!isRecoding()) {
+        if (!isRecording()) {
             return
         }
 
@@ -38,17 +38,21 @@ class ServiceScreenController(val terminal: JLine3Terminal) {
     }
 
     fun isServiceRecoding(abstractService: AbstractService): Boolean {
-        return isRecoding() && displayedAbstractService!!.name() == abstractService.name()
+        return isRecording() && displayedAbstractService!!.name() == abstractService.name()
     }
 
-    fun isRecoding(): Boolean {
+    fun isRecording(): Boolean {
         return displayedAbstractService != null
     }
 
     fun redirectCommand(command: String) {
-        if (!isRecoding()) {
+        if (!isRecording()) {
             throw IllegalStateException("Cannot redirect command to service because no service is currently being recorded.")
         }
         this.displayedAbstractService?.executeCommand(command)
+    }
+
+    fun displayedAbstractService(): AbstractService? {
+        return displayedAbstractService
     }
 }


### PR DESCRIPTION
# Pull Request

## Description
Until yet the terminal complete cloud commands in a service screen while clicking tab. The problem is that the cloud can't execute cloud commands in an active screen.

## Changes
- disable cloud command completions in an active service screen
- auto completes the `exit` command to quit the active screen
- auto completes the platform specific shutdown command

## Motivation and Context
- #506 

## How Has This Been Tested?
local cloud instance with paper and velocity services

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if necessary)
- [ ] No new warnings or errors introduced

## Screenshots (if applicable)
If there are UI changes, please include screenshots.
