### PR TITLE
Updated proxy addon (motd + maintenance) + gRPC group update implementation

### DIFF
--- a/addons/api/src/main/kotlin/dev/httpmarco/polocloud/addons/api/LegacyFormatter.kt
+++ b/addons/api/src/main/kotlin/dev/httpmarco/polocloud/addons/api/LegacyFormatter.kt
@@ -7,10 +7,20 @@ object LegacyFormatter : MessageFormatter {
         return message
     }
 
+    override fun tablistEnabled(): Boolean = true
+
     override fun formatTablistHeader(): String =
         "\n          §b§lPoloCloud §8- §7Simplest and easiest CloudSystem          \n§7Current Server: §b%server% $8| §7Players: §b%online_players%/%max_players%\n"
 
     override fun formatTablistFooter(): String =
         "\n§7Version: §b%polocloud_version%\n" +
         "§8» §7Powered by §b§lPoloCloud §8«\n"
+
+    override fun motdEnabled(): Boolean = true
+
+    override fun formatMotdLineOne(): String =
+        "§b§lPoloCloud §8» §7Simple and lightweight §8- §f%version%"
+
+    override fun formatMotdLineTwo(): String =
+        "§f§8» §7GitHub§8: §n§fgithub.polocloud.de"
 }

--- a/addons/api/src/main/kotlin/dev/httpmarco/polocloud/addons/api/MessageFormatter.kt
+++ b/addons/api/src/main/kotlin/dev/httpmarco/polocloud/addons/api/MessageFormatter.kt
@@ -3,6 +3,10 @@ package dev.httpmarco.polocloud.addons.api
 interface MessageFormatter {
     fun formatPrefix(): String
     fun format(message: String): String
+    fun tablistEnabled(): Boolean
     fun formatTablistHeader(): String
     fun formatTablistFooter(): String
+    fun motdEnabled(): Boolean
+    fun formatMotdLineOne(): String
+    fun formatMotdLineTwo(): String
 }

--- a/addons/api/src/main/kotlin/dev/httpmarco/polocloud/addons/api/MiniMessageFormatter.kt
+++ b/addons/api/src/main/kotlin/dev/httpmarco/polocloud/addons/api/MiniMessageFormatter.kt
@@ -31,10 +31,20 @@ object MiniMessageFormatter : MessageFormatter {
             .replace("§", "")
     }
 
+    override fun tablistEnabled(): Boolean = true
+
     override fun formatTablistHeader(): String =
         "\n          <gradient:#00fdee:#118bd1><bold>PoloCloud</bold></gradient> <dark_gray>- <gray>Simplest and easiest CloudSystem          \n<gray>Current Server: <aqua>%server% <dark_gray>| <gray>Players: <aqua>%online_players%/%max_players%</aqua>\n"
 
     override fun formatTablistFooter(): String
         =   "\n<gray>Version: <aqua>%polocloud_version%</aqua>\n" +
             "<dark_gray>» <gray>Powered by <gradient:#00fdee:#118bd1><bold>PoloCloud</bold></gradient> <dark_gray>«\n"
+
+    override fun formatMotdLineOne(): String =
+        "<gradient:#00fdee:#118bd1><bold>PoloCloud</bold></gradient> <dark_gray>» <gray>Simple and lightweight </gray><dark_gray>- </dark_gray><white>%version%"
+
+    override fun formatMotdLineTwo(): String =
+        "</white><dark_gray>» </dark_gray><gray>GitHub</gray><dark_gray>: </dark_gray><underlined><white>github.polocloud.de"
+
+    override fun motdEnabled(): Boolean = true
 }

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/ProxyAddon.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/ProxyAddon.kt
@@ -4,12 +4,14 @@ import dev.httpmarco.polocloud.addons.api.ConfigFactory
 import dev.httpmarco.polocloud.addons.api.LegacyFormatter
 import dev.httpmarco.polocloud.addons.api.MessageFormatter
 import dev.httpmarco.polocloud.addons.api.MiniMessageFormatter
+import dev.httpmarco.polocloud.sdk.java.Polocloud
 import java.io.File
 
 class ProxyAddon(dataFolder: File, minimessage: Boolean) {
     private val configFactory = ConfigFactory(ProxyConfiguration::class.java, dataFolder, "proxy-config.json")
     private val formatter: MessageFormatter = if (minimessage) MiniMessageFormatter else LegacyFormatter
     val config: ProxyConfigAccessor = ProxyConfigAccessor(configFactory.config)
+    var poloService = Polocloud.instance().serviceProvider().find(System.getenv("service-name"))!!
 
     init {
         applyFormatting()
@@ -30,6 +32,14 @@ class ProxyAddon(dataFolder: File, minimessage: Boolean) {
 
         if (config.tablist.footer.isEmpty()) {
             config.tablist.footer = formatter.formatTablistFooter()
+        }
+
+        if(config.motd.lineOne.isEmpty()) {
+            config.motd.lineOne = formatter.formatMotdLineOne()
+        }
+
+        if(config.motd.lineTwo.isEmpty()) {
+            config.motd.lineTwo = formatter.formatMotdLineTwo()
         }
 
         this.configFactory.save()

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/ProxyConfig.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/ProxyConfig.kt
@@ -1,5 +1,6 @@
 package dev.httpmarco.polocloud.addons.proxy
 
+import dev.httpmarco.polocloud.addons.proxy.motd.Motd
 import dev.httpmarco.polocloud.addons.proxy.tablist.Tablist
 
 interface ProxyConfig {
@@ -7,4 +8,6 @@ interface ProxyConfig {
     fun messages(key: String): String
     fun aliases(): List<String>
     fun tablist(): Tablist
+    fun motd(): Motd
+    fun maintenanceMotd(): Motd
 }

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/ProxyConfigAccessor.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/ProxyConfigAccessor.kt
@@ -1,5 +1,6 @@
 package dev.httpmarco.polocloud.addons.proxy
 
+import dev.httpmarco.polocloud.addons.proxy.motd.Motd
 import dev.httpmarco.polocloud.addons.proxy.tablist.Tablist
 
 class ProxyConfigAccessor(val config: ProxyConfiguration): ProxyConfig {
@@ -17,5 +18,13 @@ class ProxyConfigAccessor(val config: ProxyConfiguration): ProxyConfig {
 
     override fun tablist(): Tablist {
         return this.config.tablist
+    }
+
+    override fun motd(): Motd {
+        return this.config.motd
+    }
+
+    override fun maintenanceMotd(): Motd {
+        return this.config.maintenanceMotd
     }
 }

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/ProxyConfiguration.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/ProxyConfiguration.kt
@@ -1,5 +1,6 @@
 package dev.httpmarco.polocloud.addons.proxy
 
+import dev.httpmarco.polocloud.addons.proxy.motd.Motd
 import dev.httpmarco.polocloud.addons.proxy.tablist.Tablist
 
 data class ProxyConfiguration(
@@ -30,7 +31,13 @@ data class ProxyConfiguration(
         // ListSubCommand messages
         "services_header" to "<gradient:#00fdee:#118bd1><bold>Available Services</bold></gradient>",
         "service_info" to "<aqua>%service%</aqua> <gray>(</gray><green>%status%</green><gray>)</gray> <gray>→</gray> <yellow>%players%</yellow><gray>/</gray><yellow>%maxPlayers%</yellow>",
-        
+
+        // MaintenanceSubCommand messages
+        "maintenance_enabled" to "<gray>Maintenance mode has been <green>enabled</green>.</gray>",
+        "maintenance_disabled" to "<gray>Maintenance mode has been <green>disabled</green>.</gray>",
+        "maintenance_enabled_already" to "<gray>Maintenance mode is already <green>enabled</green>.</gray>",
+        "maintenance_disabled_already" to "<gray>Maintenance mode is already <green>disabled</green>.</gray>",
+
         // General usage messages
         "usage_header" to "<gray>Available <gradient:#00fdee:#118bd1><bold>/polocloud</bold></gradient> commands:",
         "usage_info" to "<aqua>/polocloud info</aqua>",
@@ -42,5 +49,7 @@ data class ProxyConfiguration(
         "usage_broadcast" to "<aqua>/polocloud broadcast <message></aqua>"
     ),
     val aliases: List<String> = listOf("cloud", "p"),
-    val tablist: Tablist = Tablist()
+    val tablist: Tablist = Tablist(),
+    val motd: Motd = Motd(),
+    val maintenanceMotd: Motd = Motd()
 )

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/motd/Motd.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/motd/Motd.kt
@@ -1,0 +1,7 @@
+package dev.httpmarco.polocloud.addons.proxy.motd
+
+class Motd {
+    var enabled: Boolean = true
+    var lineOne: String = ""
+    var lineTwo: String = ""
+}

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/VelocityCloudCommand.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/VelocityCloudCommand.kt
@@ -6,6 +6,7 @@ import dev.httpmarco.polocloud.addons.proxy.ProxyAddon
 import dev.httpmarco.polocloud.addons.proxy.ProxyConfig
 import dev.httpmarco.polocloud.addons.proxy.platform.velocity.subcommands.InfoSubCommand
 import dev.httpmarco.polocloud.addons.proxy.platform.velocity.subcommands.ListSubCommand
+import dev.httpmarco.polocloud.addons.proxy.platform.velocity.subcommands.MaintenanceSubCommand
 import dev.httpmarco.polocloud.addons.proxy.platform.velocity.subcommands.PlayersSubCommand
 import dev.httpmarco.polocloud.addons.proxy.platform.velocity.subcommands.StartSubCommand
 import dev.httpmarco.polocloud.addons.proxy.platform.velocity.subcommands.StopSubCommand
@@ -25,7 +26,7 @@ class VelocityCloudCommand(
         "players" to PlayersSubCommand(proxyAddon, proxyServer),
         //"create" to CreateSubCommand(proxyAddon),
         //"delete" to DeleteSubCommand(proxyAddon),
-        //"maintenance" to MaintenanceSubCommand(proxyAddon),
+        "maintenance" to MaintenanceSubCommand(proxyAddon),
         //"broadcast" to BroadcastSubCommand(proxyAddon)
     )
 

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/VelocityMotdUpdater.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/VelocityMotdUpdater.kt
@@ -1,0 +1,63 @@
+package dev.httpmarco.polocloud.addons.proxy.platform.velocity
+
+import com.velocitypowered.api.event.Subscribe
+import com.velocitypowered.api.event.proxy.ProxyPingEvent
+import com.velocitypowered.api.proxy.ProxyServer
+import com.velocitypowered.api.proxy.server.ServerPing
+import dev.httpmarco.polocloud.addons.proxy.ProxyConfigAccessor
+import net.kyori.adventure.text.minimessage.MiniMessage
+
+class VelocityMotdUpdater (
+    private val platform: VelocityPlatform,
+    private val server: ProxyServer,
+    private val config: ProxyConfigAccessor
+) {
+
+    private val polocloudVersion: String = System.getenv("polocloud-version") ?: "unknown"
+
+    @Subscribe
+    fun onProxyPing(event: ProxyPingEvent) {
+        if(platform.proxyAddon().poloService.properties["maintenance"]?.toBoolean() ?: false) {
+            // maintenance mode is enabled, use maintenance MOTD
+            if(!config.maintenanceMotd().enabled) {
+                // maintenance motd is disabled
+                return
+            }
+            val motdLines = config.maintenanceMotd().lineOne + "\n" + config.maintenanceMotd().lineTwo
+            val newPing = ServerPing.builder()
+                .description(MiniMessage.miniMessage().deserialize(motdLines))
+                .version(event.ping.version)
+                .maximumPlayers(event.ping.players.orElse(null)?.max ?: 0)
+                .onlinePlayers(event.ping.players.orElse(null)?.online ?: 0)
+
+            event.ping = newPing.build()
+            return
+        }
+
+        if(!config.motd().enabled) {
+            // motd module is disabled
+            return
+        }
+
+        val ping = event.ping
+        if(ping == null) {
+            // no ping data available
+            return
+        }
+
+        var motdLines = config.motd().lineOne + "\n" + config.motd().lineTwo
+        motdLines = motdLines
+            .replace("%version%", polocloudVersion)
+            .replace("%online_players%", server.playerCount.toString())
+
+        val newPing = ServerPing.builder()
+            .description(MiniMessage.miniMessage().deserialize(motdLines))
+            .version(ping.version)
+            .maximumPlayers(ping.players.orElse(null) ?.max ?: 0)
+            .onlinePlayers(ping.players.orElse(null)?.online ?: 0)
+
+        event.ping = newPing.build()
+
+    }
+
+}

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/VelocityPlatform.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/VelocityPlatform.kt
@@ -26,6 +26,13 @@ class VelocityPlatform @Inject constructor(
             VelocityCloudCommand(this.proxyAddon, server),
         )
 
+        val eventManager = this.server.eventManager
+        eventManager.register(this, VelocityMotdUpdater(this, server, config))
+
         VelocityTablistUpdater( this, server, config)
+    }
+
+    fun proxyAddon(): ProxyAddon {
+        return this.proxyAddon
     }
 }

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/VelocityTablistUpdater.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/VelocityTablistUpdater.kt
@@ -24,6 +24,10 @@ class VelocityTablistUpdater (
     }
 
     private fun updateAll() {
+        if( !this.config.tablist().enabled) {
+            // tablist module is disabled
+            return
+        }
         val configHeader = this.config.tablist().header
         val configFooter = this.config.tablist().footer
 

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/subcommands/MaintenanceSubCommand.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/platform/velocity/subcommands/MaintenanceSubCommand.kt
@@ -1,0 +1,75 @@
+package dev.httpmarco.polocloud.addons.proxy.platform.velocity.subcommands
+
+import com.google.gson.JsonPrimitive
+import com.velocitypowered.api.command.CommandSource
+import dev.httpmarco.polocloud.addons.proxy.CloudSubCommand
+import dev.httpmarco.polocloud.addons.proxy.ProxyAddon
+import dev.httpmarco.polocloud.sdk.java.Polocloud
+import net.kyori.adventure.text.minimessage.MiniMessage
+
+class MaintenanceSubCommand(val proxyAddon: ProxyAddon): CloudSubCommand {
+
+    private val miniMessage = MiniMessage.miniMessage()
+
+    override fun execute(
+        source: CommandSource,
+        arguments: List<String>
+    ) {
+        val config = proxyAddon.config
+
+        if (!source.hasPermission("polocloud.addons.proxy.command.cloud.maintenance")) {
+            source.sendMessage(miniMessage.deserialize(config.prefix() + config.messages("no_permission")))
+            return
+        }
+
+        if (arguments.isEmpty()) {
+            source.sendMessage(miniMessage.deserialize(config.prefix() + config.messages("usage_maintenance")))
+            return
+        }
+
+        val action = arguments[0].lowercase()
+
+        when (action) {
+            "on" -> {
+
+                val group = Polocloud.instance().groupProvider().find(proxyAddon.poloService.groupName)!!
+                val maintenanceEnabled = group.properties["maintenance"]?.asBoolean ?: false
+                if(maintenanceEnabled) {
+                    source.sendMessage(miniMessage.deserialize(config.prefix() + config.messages("maintenance_enabled_already")))
+                    return
+                }
+
+                val properties = HashMap<String, JsonPrimitive>()
+                group.properties.forEach { properties[it.key] = it.value }
+                properties["maintenance"] = JsonPrimitive(true)
+                Polocloud.instance().groupProvider().update(group)
+
+                proxyAddon.poloService = Polocloud.instance().serviceProvider().find(System.getenv("service-name"))!!
+                source.sendMessage(miniMessage.deserialize(config.prefix() + config.messages("maintenance_enabled")))
+
+            }
+            "off" -> {
+
+                val group = Polocloud.instance().groupProvider().find(proxyAddon.poloService.groupName)!!
+                val maintenanceEnabled = group.properties["maintenance"]?.asBoolean ?: false
+                if(!maintenanceEnabled) {
+                    source.sendMessage(miniMessage.deserialize(config.prefix() + config.messages("maintenance_disabled_already")))
+                    return
+                }
+
+                val properties = HashMap<String, JsonPrimitive>()
+                group.properties.forEach { properties[it.key] = it.value }
+                properties["maintenance"] = JsonPrimitive(false)
+                Polocloud.instance().groupProvider().update(group)
+
+                proxyAddon.poloService = Polocloud.instance().serviceProvider().find(System.getenv("service-name"))!!
+                source.sendMessage(miniMessage.deserialize(config.prefix() + config.messages("maintenance_disabled")))
+
+            }
+            else -> {
+                source.sendMessage(miniMessage.deserialize(config.prefix() + config.messages("usage_maintenance")))
+            }
+        }
+
+    }
+}

--- a/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/tablist/Tablist.kt
+++ b/addons/proxy/src/main/kotlin/dev/httpmarco/polocloud/addons/proxy/tablist/Tablist.kt
@@ -1,6 +1,7 @@
 package dev.httpmarco.polocloud.addons.proxy.tablist
 
 data class Tablist(
+    var enabled: Boolean = true,
     var header: String = "",
     var footer: String = "",
 )

--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/groups/AbstractGroup.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/groups/AbstractGroup.kt
@@ -38,7 +38,7 @@ open class AbstractGroup(
 
     fun update() {
         // update the group
-        Agent.runtime.groupStorage().update(this)
+        Agent.runtime.groupStorage().updateGroup(this)
     }
 
     fun serviceCount(): Int {

--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/RuntimeGroupStorage.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/RuntimeGroupStorage.kt
@@ -5,7 +5,7 @@ import dev.httpmarco.polocloud.shared.groups.SharedGroupProvider
 
 interface RuntimeGroupStorage : SharedGroupProvider<AbstractGroup>{
 
-    fun update(group: AbstractGroup)
+    fun updateGroup(group: AbstractGroup)
 
     fun reload()
 

--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/docker/DockerRuntimeGroupStorage.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/docker/DockerRuntimeGroupStorage.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.CompletableFuture
 
 class DockerRuntimeGroupStorage : RuntimeGroupStorage {
 
-    override fun update(group: AbstractGroup) {
+    override fun updateGroup(group: AbstractGroup) {
         TODO("Not yet implemented")
     }
 
@@ -44,6 +44,14 @@ class DockerRuntimeGroupStorage : RuntimeGroupStorage {
     }
 
     override fun createAsync(group: AbstractGroup): CompletableFuture<AbstractGroup?> {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(group: AbstractGroup): AbstractGroup? {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateAsync(group: AbstractGroup): CompletableFuture<AbstractGroup?> {
         TODO("Not yet implemented")
     }
 

--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/k8s/KubernetesRuntimeGroupStorage.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/k8s/KubernetesRuntimeGroupStorage.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture
 
 class KubernetesRuntimeGroupStorage(private val kubeClient: KubernetesClient) : RuntimeGroupStorage {
 
-    override fun update(group: AbstractGroup) {
+    override fun updateGroup(group: AbstractGroup) {
         TODO("Not yet implemented")
     }
 
@@ -31,7 +31,19 @@ class KubernetesRuntimeGroupStorage(private val kubeClient: KubernetesClient) : 
             .getItems()
             .stream()
             // todo
-            .map({ group -> AbstractGroup(group.name, 0, 0, 0, 0, 0.0, PlatformIndex("", ""), emptyList(), hashMapOf()) })
+            .map { group ->
+                AbstractGroup(
+                    group.name,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0.0,
+                    PlatformIndex("", ""),
+                    emptyList(),
+                    hashMapOf()
+                )
+            }
             .toList()
     }
 
@@ -52,6 +64,14 @@ class KubernetesRuntimeGroupStorage(private val kubeClient: KubernetesClient) : 
     }
 
     override fun createAsync(group: AbstractGroup): CompletableFuture<AbstractGroup?> {
+        TODO("Not yet implemented")
+    }
+
+    override fun update(group: AbstractGroup): AbstractGroup? {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateAsync(group: AbstractGroup): CompletableFuture<AbstractGroup?> {
         TODO("Not yet implemented")
     }
 

--- a/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/LocalRuntimeGroupStorage.kt
+++ b/agent/src/main/kotlin/dev/httpmarco/polocloud/agent/runtime/local/LocalRuntimeGroupStorage.kt
@@ -42,7 +42,7 @@ class LocalRuntimeGroupStorage : RuntimeGroupStorage {
         this.groupPath(abstractGroup).deleteIfExists()
     }
 
-    override fun update(group: AbstractGroup) {
+    override fun updateGroup(group: AbstractGroup) {
         // overwrite the existing group file with the new data
         Files.writeString(groupPath(group), PRETTY_GSON.toJson(group))
     }
@@ -79,6 +79,16 @@ class LocalRuntimeGroupStorage : RuntimeGroupStorage {
 
     override fun createAsync(group: AbstractGroup): CompletableFuture<AbstractGroup?> {
         return CompletableFuture.completedFuture(create(group))
+    }
+
+    override fun update(group: AbstractGroup): AbstractGroup? {
+        val existingGroup = this.find(group.name) ?: return null
+        this.updateGroup(group)
+        return group
+    }
+
+    override fun updateAsync(group: AbstractGroup): CompletableFuture<AbstractGroup?> {
+        return CompletableFuture.completedFuture(update(group))
     }
 
     override fun delete(name: String): AbstractGroup? {

--- a/proto/src/main/proto/polocloud/v1/proto/group_provider.proto
+++ b/proto/src/main/proto/polocloud/v1/proto/group_provider.proto
@@ -11,6 +11,7 @@ import "google/protobuf/struct.proto";
 service GroupController {
   rpc find(FindGroupRequest) returns (FindGroupResponse);
   rpc create(GroupCreateRequest) returns (GroupCreateResponse);
+  rpc update(GroupUpdateRequest) returns (GroupUpdateResponse);
   rpc delete(GroupDeleteRequest) returns (GroupDeleteResponse);
 }
 
@@ -37,6 +38,23 @@ message GroupCreateRequest {
 }
 
 message GroupCreateResponse {
+  GroupSnapshot group = 1;
+}
+
+message GroupUpdateRequest {
+  string name = 1;
+  GroupType type = 2;
+  PlatformSnapshot platform = 3;
+  int32 minimumMemory = 4;
+  int32 maximumMemory = 5;
+  int32 minimumOnline = 6;
+  int32 maximumOnline = 7;
+  double percentageToStartNewService = 8;
+  repeated string templates = 9;
+  map<string, string> properties = 10;
+}
+
+message GroupUpdateResponse {
   GroupSnapshot group = 1;
 }
 

--- a/sdk/sdk-java/src/main/java/dev/httpmarco/polocloud/sdk/java/groups/GroupProvider.java
+++ b/sdk/sdk-java/src/main/java/dev/httpmarco/polocloud/sdk/java/groups/GroupProvider.java
@@ -85,6 +85,44 @@ public class GroupProvider implements SharedGroupProvider<Group> {
     }
 
     @Override
+    public Group update(@NotNull Group group) {
+        var snapshot = group.toSnapshot();
+        return Group.Companion.bindSnapshot(blockingStub.update(
+                GroupUpdateRequest.newBuilder()
+                        .setName(snapshot.getName())
+                        .setType(snapshot.getType())
+                        .setPlatform(snapshot.getPlatform())
+                        .setMinimumMemory(snapshot.getMinimumMemory())
+                        .setMaximumMemory(snapshot.getMaximumMemory())
+                        .setMinimumOnline(snapshot.getMinimumOnline())
+                        .setMaximumOnline(snapshot.getMaximumOnline())
+                        .setPercentageToStartNewService(snapshot.getPercentageToStartNewService())
+                        .addAllTemplates(snapshot.getTemplatesList())
+                        .putAllProperties(snapshot.getPropertiesMap())
+                        .build()
+        ).getGroup());
+    }
+
+    @Override
+    public CompletableFuture<Group> updateAsync(@NotNull Group group) {
+        var snapshot = group.toSnapshot();
+        return FutureConverterKt.completableFromGuava(futureStub.update(
+                GroupUpdateRequest.newBuilder()
+                        .setName(snapshot.getName())
+                        .setType(snapshot.getType())
+                        .setPlatform(snapshot.getPlatform())
+                        .setMinimumMemory(snapshot.getMinimumMemory())
+                        .setMaximumMemory(snapshot.getMaximumMemory())
+                        .setMinimumOnline(snapshot.getMinimumOnline())
+                        .setMaximumOnline(snapshot.getMaximumOnline())
+                        .setPercentageToStartNewService(snapshot.getPercentageToStartNewService())
+                        .addAllTemplates(snapshot.getTemplatesList())
+                        .putAllProperties(snapshot.getPropertiesMap())
+                        .build()
+        ), groupSnapshot -> Group.Companion.bindSnapshot(groupSnapshot.getGroup()));
+    }
+
+    @Override
     @Nullable
     public Group delete(@NotNull String name) {
         return Group.Companion.bindSnapshot(blockingStub.delete(GroupDeleteRequest.newBuilder().setName(name).build()).getGroup());

--- a/shared/src/main/kotlin/dev/httpmarco/polocloud/shared/groups/SharedGroupProvider.kt
+++ b/shared/src/main/kotlin/dev/httpmarco/polocloud/shared/groups/SharedGroupProvider.kt
@@ -16,6 +16,10 @@ interface SharedGroupProvider<G: Group> {
 
     fun createAsync(group: G) : CompletableFuture<G?>
 
+    fun update(group: G): G?
+
+    fun updateAsync(group: G) : CompletableFuture<G?>
+
     fun delete(name: String) : G?
 
 }


### PR DESCRIPTION
# Pull Request

## Description
The proxy addon has implemented configurable motd lines and a maintenance mode that can enable and disable via cloud command `/cloud maintenance <on|off>`

## Changes
- proxy addon motd files
- proxy addon maintenance files
- gRPC update implementation

## Motivation and Context
- #481 

## How Has This Been Tested?
local cloud instance

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if necessary)
- [ ] No new warnings or errors introduced

## Screenshots (if applicable)
If there are UI changes, please include screenshots.
