### PR TITLE
fix: use default port for standalone usage

### DIFF
--- a/sdk/sdk-java/src/main/java/dev/httpmarco/polocloud/sdk/java/Polocloud.java
+++ b/sdk/sdk-java/src/main/java/dev/httpmarco/polocloud/sdk/java/Polocloud.java
@@ -46,7 +46,7 @@ public final class Polocloud extends PolocloudShared {
     }
 
     Polocloud() {
-        this(null, Integer.parseInt(System.getenv("agent_port")), true);
+        this(null, System.getenv().containsKey("agent_port") ? Integer.parseInt(System.getenv("agent_port")) : 8932, true); // use default port for standalone
         instance = this;
     }
 


### PR DESCRIPTION
# Pull Request

## Description
If the java-sdk used standalone, the environment variable "agent_port" is null. Now the java-sdk try to connect to polocloud default port if the agent_port ist null.

## Changes
- add default port fallback if agent_port is unset

## Motivation and Context
/ 

## How Has This Been Tested?
/ 

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Tests have been added/updated
- [ ] Documentation has been updated (if necessary)
- [ ] No new warnings or errors introduced

## Screenshots (if applicable)
If there are UI changes, please include screenshots.
